### PR TITLE
#76: use port 9001, instead of 90001 (not possible)

### DIFF
--- a/src/js/initializer.js
+++ b/src/js/initializer.js
@@ -8,7 +8,7 @@ var websocket = null;
 //var websocket_uri = "ws://108.59.3.115:18875";
 
 // URL of the WebSocket server (whisper)
-var websocket_uri = "ws://localhost:90001";
+var websocket_uri = "ws://localhost:9001";
 
 var audio_context;
 var recorder = null;

--- a/websocket/server.py
+++ b/websocket/server.py
@@ -54,5 +54,5 @@ if __name__ == '__main__':
    factory = WebSocketServerFactory("ws://localhost:90001", debug = False)
    factory.protocol = MyServerProtocol
 
-   reactor.listenTCP(90001, factory)
+   reactor.listenTCP(9001, factory)
    reactor.run()


### PR DESCRIPTION
Resolves #76.
